### PR TITLE
Fix import of utils in examples and documentation

### DIFF
--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -14,5 +14,5 @@ BFASTMonitor Implementation
 Helper Functions
 ----------------
 
-.. automodule:: bfast.utils
+.. automodule:: bfast.monitor.utils
     :members: crop_data_dates

--- a/examples/howto.py
+++ b/examples/howto.py
@@ -24,7 +24,7 @@ with open(ifile_meta) as f:
     dates = [datetime.strptime(d, '%Y-%m-%d') for d in dates if len(d) > 0]
 
 # define history and monitoring period and crop input data
-from bfast.utils import crop_data_dates
+from bfast.monitor.utils import crop_data_dates
 start_hist = datetime(2002, 1, 1)
 start_monitor = datetime(2010, 1, 1)
 end_monitor = datetime(2018, 1, 1)

--- a/examples/peru_small_opencl.py
+++ b/examples/peru_small_opencl.py
@@ -9,7 +9,7 @@ import matplotlib
 from datetime import datetime
 
 from bfast import BFASTMonitor
-from bfast.utils import crop_data_dates
+from bfast.monitor.utils import crop_data_dates
 
 # parameters
 k = 3

--- a/examples/peru_small_python.py
+++ b/examples/peru_small_python.py
@@ -4,7 +4,7 @@ import numpy
 from datetime import datetime
 
 from bfast import BFASTMonitor
-from bfast.utils import crop_data_dates
+from bfast.monitor.utils import crop_data_dates
 
 import copy
 

--- a/examples/peru_small_python_big.py
+++ b/examples/peru_small_python_big.py
@@ -9,7 +9,7 @@ import matplotlib
 from datetime import datetime
 
 from bfast import BFASTMonitor
-from bfast.utils import crop_data_dates
+from bfast.monitor.utils import crop_data_dates
 
 # parameters
 k = 3

--- a/examples/validator.py
+++ b/examples/validator.py
@@ -11,7 +11,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 
 from bfast import BFASTMonitor
-from bfast.utils import crop_data_dates
+from bfast.monitor.utils import crop_data_dates
 
 
 def cached(file_name):


### PR DESCRIPTION
Currently examples will not run because `utils.py` was moved in commit 05dc8070f65ae2bc8a82396c1fd504aeeb6ed7d1.
This also causes [some documentation to be missing (empty section) on your site](https://bfast.readthedocs.io/en/latest/reference.html#module-bfast.utils).

Both should be fixed with this commit, but I have only tested the example part.